### PR TITLE
json.loads() is decrecated and removed in Python3.9

### DIFF
--- a/ninjarmmpy/utils.py
+++ b/ninjarmmpy/utils.py
@@ -1,5 +1,4 @@
 from functools import wraps
-import json
 import requests
 from ninjarmmpy.auth import NinjaAuthentication
 
@@ -10,7 +9,7 @@ def return_response(fn):
         response = fn(*args, **kwargs)
         if not response.status_code:
             return response.status_code
-        return json.loads(response.text)
+        return response.json()
     return wrapped
 
 


### PR DESCRIPTION
An error I got:

Traceback (most recent call last):
File "C:\Users\SOMEUSER\AppData\Local\Programs\Python\Python39\lib\site-packages\ninjarmmpy\utils.py", line 13, in wrapped
return json.loads(response.text)
File "C:\Users\SOMEUSER\AppData\Local\Programs\Python\Python39\lib\json_init_.py", line 346, in loads
return _default_decoder.decode(s)
File "C:\Users\SOMEUSER\AppData\Local\Programs\Python\Python39\lib\json\decoder.py", line 337, in decode
obj, end = self.raw_decode(s, idx=_w(s, 0).end())
File "C:\Users\SOMEUSER\AppData\Local\Programs\Python\Python39\lib\json\decoder.py", line 355, in raw_decode
raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)